### PR TITLE
fix makeChatlog

### DIFF
--- a/ruka-chap7/actions/makeChatlog.js
+++ b/ruka-chap7/actions/makeChatlog.js
@@ -35,9 +35,7 @@
       .join('\n\n')
 
     // 文字列をエスケープして対話メモリへ格納する（前後のクォートは外す）
-    temp.chatlog = JSON.stringify(logText)
-      .slice(1)
-      .slice(0, -1)
+    temp.chatlog = JSON.stringify(logText).slice(1, -1)
   }
 
   return makeChatlog()

--- a/ruka-chap7/actions/makeChatlog.js
+++ b/ruka-chap7/actions/makeChatlog.js
@@ -1,5 +1,3 @@
-  const axios = require('axios')
-
   /**
    * 現在のセッションの会話ログをエスケープ済の文字列にしてtemp.chatlogに格納する
    * @title 会話ログ取得
@@ -7,28 +5,34 @@
    * @author nakmas
    */
   const makeChatlog = async () => {
-    // WebChatモジュールのREST APIから会話ログを取得
-    const conversationId = event.threadId
-    const userId = event.target
-    const botId = event.botId
-    const path = `/mod/channel-web/conversations/${userId}/${conversationId}`
-    const axiosConfig = await bp.http.getAxiosConfigForBot(event.botId)
-    const res = await axios.get(path, axiosConfig)
+    // この会話の直近100件のイベントを取得する
+    const historicalEvents = await bp.events.findEvents(
+      {
+        botId: event.botId,
+        threadId: event.threadId,
+        channel: 'web'
+      },
+      {
+        sortOrder: [{column: 'createdOn', desc: true}],
+        from: 0,
+        count: 100
+      }
+    )
 
-    // 取得した構造データから、読めるテキストを作る
-    const logText = res.data.messages
-      .reduce((memo, mes) => {
-        if (mes.message_type === 'text' || mes.message_type === 'quick_reply') {
-          memo.push([mes.full_name, mes.sent_on, mes.message_text])
-        }
-        if (mes.message_type === 'custom' && mes.payload.component === 'QuickReplies') {
-          memo.push([mes.full_name, mes.sent_on, mes.payload.wrapped.text])
+    // 取得したイベントデータから、読めるテキストを作る
+    const logText = historicalEvents
+      .sort((a, b) => parseInt(a.id) - parseInt(b.id))
+      .reduce((memo, event) => {
+        if (event.event.preview) {
+          const sender = event.direction === 'incoming' ? 'User' : 'Bot'
+          const date = event.createdOn
+          const text = event.event.preview.trim()
+          memo.push({sender, date, text})
         }
         return memo
       }, [])
-      .map(ary => `${ary[0]} (${ary[1]}):\n${ary[2]}`)
+      .map(({sender, date, text}) => `${sender} (${date}):\n${text}`)
       .join('\n\n')
-
 
     // 文字列をエスケープして対話メモリへ格納する（前後のクォートは外す）
     temp.chatlog = JSON.stringify(logText)


### PR DESCRIPTION
会話履歴の取得元を、WebChatモジュールのREST APIからBotpress SDKへ変更。
（最近のBotpressではREST API仕様が変わってしまったため）