### PR TITLE
初回起動時に商品情報が表示できないバグを修正

### DIFF
--- a/ruka-chap7/media/shop.html
+++ b/ruka-chap7/media/shop.html
@@ -74,7 +74,7 @@
 
   // プロアクティブ化
   window.addEventListener('message', function (event) {
-    if (event.data.name === 'webchatReady') { // 書籍の初版から変更
+    if (event.data.payload && event.data.payload.type === 'visit') { // v12.26に対応した書き方
       window.botpressWebChat.sendEvent({
         type: 'proactive-trigger',
         channel: 'web',


### PR DESCRIPTION
問題の原因は、webchatReadyイベントのタイミングではまだevent.state.userに保存ができなかったため。
そのため、visitイベントを使うように再修正。